### PR TITLE
Yarn support and Makefile fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,4 @@ install:
 
 build:
 	cd ./web/static && npm run build && cd ../../
-	rm -rf ./priv/static
-	mkdir ./priv/static
-	cp -r ./web/static/build/ ./priv/static
+	mv ./web/static/build/ ./priv/static/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 install:
 	mix deps.get
-	cd ./web/static && npm install && cd ../../
+	cd ./web/static && yarn && cd ../../
 
 build:
 	cd ./web/static && npm run build && cd ../../
+	rm -rf ./priv/static/
 	mv ./web/static/build/ ./priv/static/

--- a/README.md
+++ b/README.md
@@ -1,19 +1,25 @@
 # EveryColor
 
-To start your Phoenix app:
+### Running
 
-  * Install dependencies with `mix deps.get`
-  * Create and migrate your database with `mix ecto.create && mix ecto.migrate`
-  * Start Phoenix endpoint with `mix phoenix.server`
+You have to have Node with `yarn` installed.
 
-Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
+First clone front-end repo as well: 
+```
+git submodule update --init --recursive
+```
 
-Ready to run in production? Please [check our deployment guides](http://www.phoenixframework.org/docs/deployment).
+Next you can install both Elixir and Node dependencies:
 
-## Learn more
+```
+make install 
+```
 
-  * Official website: http://www.phoenixframework.org/
-  * Guides: http://phoenixframework.org/docs/overview
-  * Docs: https://hexdocs.pm/phoenix
-  * Mailing list: http://groups.google.com/group/phoenix-talk
-  * Source: https://github.com/phoenixframework/phoenix
+When all dependencies are installed, you can build front-end part and start server:
+
+```
+make build && mix phoenix.server
+```
+
+Now your server is available at: `localhost:4000`.
+


### PR DESCRIPTION
Now yarn is required to run `make install`. If you want to use `npm` you have to manually run:
```
cd web/static
npm install 
cd ../../
```